### PR TITLE
Fixed the `AgentCommunicationChannelDefinition` by adding a new `Type` property

### DIFF
--- a/src/DClare.Sdk/AgentCommunicationChannelType.cs
+++ b/src/DClare.Sdk/AgentCommunicationChannelType.cs
@@ -14,19 +14,15 @@
 namespace DClare.Sdk;
 
 /// <summary>
-/// Enumerates all types of agents
+/// Enumerates all types of agent communication channels
 /// </summary>
-public static class AgentType
+public static class AgentCommunicationChannelType
 {
 
     /// <summary>
-    /// Indicates a fully defined, locally hosted agent whose behavior and capabilities are described inline
+    /// Indicates a channel using the Agent2Agent protocol
     /// </summary>
-    public const string Hosted = "hosted";
-    /// <summary>
-    /// Indicates a remote agent referenced via an external endpoint
-    /// </summary>
-    public const string Remote = "remote";
+    public const string A2A = "a2a";
 
     /// <summary>
     /// Gets an <see cref="IEnumerable{T}"/> containing all supported values
@@ -34,8 +30,7 @@ public static class AgentType
     /// <returns>A new <see cref="IEnumerable{T}"/></returns>
     public static IEnumerable<string> AsEnumerable()
     {
-        yield return Hosted;
-        yield return Remote;
+        yield return A2A;
     }
 
 }

--- a/src/DClare.Sdk/Models/AgentCommunicationChannelDefinition.cs
+++ b/src/DClare.Sdk/Models/AgentCommunicationChannelDefinition.cs
@@ -17,7 +17,7 @@ namespace DClare.Sdk.Models;
 /// Represents the definition of protocol-specific configuration options for communicating with a remote agent
 /// </summary>
 [DataContract]
-public record RemoteAgentCommunicationChannelDefinition
+public record AgentCommunicationChannelDefinition
 {
 
     /// <summary>
@@ -25,5 +25,11 @@ public record RemoteAgentCommunicationChannelDefinition
     /// </summary>
     [DataMember(Name = "a2a", Order = 1), JsonPropertyName("a2a"), JsonPropertyOrder(1), YamlMember(Alias = "a2a", Order = 1)]
     public virtual A2AChannelConfiguration? A2A { get; set; }
+
+    /// <summary>
+    /// Gets the agent's type
+    /// </summary>
+    [IgnoreDataMember, JsonIgnore, YamlIgnore]
+    public virtual string Type => A2A != null ? AgentCommunicationChannelType.A2A : null!;
 
 }

--- a/src/DClare.Sdk/Models/RemoteAgentDefinition.cs
+++ b/src/DClare.Sdk/Models/RemoteAgentDefinition.cs
@@ -25,6 +25,6 @@ public record RemoteAgentDefinition
     /// </summary>
     [Required]
     [DataMember(Name = "channel", Order = 1), JsonPropertyName("channel"), JsonPropertyOrder(1), YamlMember(Alias = "channel", Order = 1)]
-    public virtual RemoteAgentCommunicationChannelDefinition Channel { get; set; } = null!;
+    public virtual AgentCommunicationChannelDefinition Channel { get; set; } = null!;
 
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Renames the `RemoteAgentCommunicationChannelDefinition` into `AgentCommunicationChannelDefinition`
- Fixes the `AgentCommunicationChannelDefinition` by adding a new `Type` property