### PR TITLE
Added agent name selector to `A2AChannelConfiguration` and clarify discovery endpoint usage

### DIFF
--- a/src/DClare.Sdk/DClare.Sdk.csproj
+++ b/src/DClare.Sdk/DClare.Sdk.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/DClare.Sdk/Models/A2AChannelConfiguration.cs
+++ b/src/DClare.Sdk/Models/A2AChannelConfiguration.cs
@@ -21,10 +21,18 @@ public record A2AChannelConfiguration
 {
 
     /// <summary>
-    /// Gets/sets the remote agent's A2A endpoint
+    /// Gets/sets the endpoint of the remote host used to perform A2A agent discovery<para></para>
+    /// This is not the agent’s direct message endpoint, but rather the host through which the agent is resolved
     /// </summary>
     [Required]
     [DataMember(Name = "endpoint", Order = 1), JsonPropertyName("endpoint"), JsonPropertyOrder(1), YamlMember(Alias = "endpoint", Order = 1)]
     public virtual EndpointDefinition Endpoint { get; set; } = null!;
+
+    /// <summary>
+    /// Gets/sets the name or identifier of the remote agent to select from the A2A discovery endpoint, in case multiple agents are available at the same host
+    /// </summary>
+    [Required]
+    [DataMember(Name = "name", Order = 2), JsonPropertyName("name"), JsonPropertyOrder(2), YamlMember(Alias = "name", Order = 2)]
+    public virtual string? Name { get; set; }
 
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Added `Name` property to `A2AChannelConfiguration` to specify which agent to use when the discovery endpoint exposes multiple agents.
- Updated the summary of the existing `Endpoint` property to clarify that it refers to the A2A discovery host, not the agent's direct communication endpoint.