### PR TITLE
Fixed the `KernelFunctionDefinition` by removing the `MinLengthAttribute` from its `Template` property

### DIFF
--- a/src/DClare.Sdk/DClare.Sdk.csproj
+++ b/src/DClare.Sdk/DClare.Sdk.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/DClare.Sdk/Extensions/IServiceCollectionExtensions.cs
+++ b/src/DClare.Sdk/Extensions/IServiceCollectionExtensions.cs
@@ -27,7 +27,12 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddDClare(this IServiceCollection services)
     {
         services.AddJsonSerializer();
-        services.AddYamlDotNetSerializer();
+        services.AddYamlDotNetSerializer(options =>
+        {
+            Neuroglia.Serialization.Yaml.YamlSerializer.DefaultSerializerConfiguration(options.Serializer);
+            Neuroglia.Serialization.Yaml.YamlSerializer.DefaultDeserializerConfiguration(options.Deserializer);
+            options.Serializer.DisableAliases();
+        });
         services.AddValidatorsFromAssemblyContaining<WorkflowDefinition>();
         var defaultPropertyNameResolver = ValidatorOptions.Global.PropertyNameResolver;
         ValidatorOptions.Global.PropertyNameResolver = (type, member, lambda) => member == null ? defaultPropertyNameResolver(type, member, lambda) : member.Name.ToCamelCase();

--- a/src/DClare.Sdk/Models/KernelFunctionDefinition.cs
+++ b/src/DClare.Sdk/Models/KernelFunctionDefinition.cs
@@ -24,7 +24,7 @@ public record KernelFunctionDefinition
     /// <summary>
     /// Gets/sets the function's prompt template
     /// </summary>
-    [Required, MinLength(3)]
+    [Required]
     [DataMember(Name = "template", Order = 1), JsonPropertyName("template"), JsonPropertyOrder(1), YamlMember(Alias = "template", Order = 1)]
     public virtual PromptTemplateDefinition Template { get; set; } = null!;
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `KernelFunctionDefinition` by removing the `MinLengthAttribute` from its `Template` property
- Fixes the `IServiceCollectionExtensions` by disabling YAML aliases