### PR TITLE
Updated the `HostedAgentDefinition` by adding a `Title` and a `Documentation` property

### DIFF
--- a/src/DClare.Sdk/DClare.Sdk.csproj
+++ b/src/DClare.Sdk/DClare.Sdk.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/DClare.Sdk/Extensions/ComponentDefinitionCollectionExtensions.cs
+++ b/src/DClare.Sdk/Extensions/ComponentDefinitionCollectionExtensions.cs
@@ -1,0 +1,96 @@
+﻿// Copyright © 2025-Present The DClare Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace DClare.Sdk;
+
+/// <summary>
+/// Defines extensions for <see cref="ComponentDefinitionCollection"/>s
+/// </summary>
+public static class ComponentDefinitionCollectionExtensions
+{
+
+    /// <summary>
+    /// Gets the specified <see cref="ReferenceableComponentDefinition"/>.
+    /// </summary>
+    /// <typeparam name="TComponent">The type of the <see cref="ReferenceableComponentDefinition"/> to get.</typeparam>
+    /// <param name="collection">The <see cref="ComponentDefinitionCollection"/> that defines the <see cref="ReferenceableComponentDefinition"/> to get.</param>
+    /// <param name="name">The name of the <see cref="ReferenceableComponentDefinition"/> to get.</param>
+    /// <returns>The <see cref="ReferenceableComponentDefinition"/> with the specified name, if any.</returns>
+    public static TComponent? Get<TComponent>(this ComponentDefinitionCollection collection, string name) where TComponent : ReferenceableComponentDefinition => (TComponent?)collection.Get(typeof(TComponent), name);
+
+    /// <summary>
+    /// Gets the specified <see cref="ReferenceableComponentDefinition"/>.
+    /// </summary>
+    /// <param name="collection">The <see cref="ComponentDefinitionCollection"/> that defines the <see cref="ReferenceableComponentDefinition"/> to get.</param>
+    /// <param name="type">The The type of the <see cref="ReferenceableComponentDefinition"/> to get.</param>
+    /// <param name="name">The name of the <see cref="ReferenceableComponentDefinition"/> to get.</param>
+    /// <returns>The <see cref="ReferenceableComponentDefinition"/> with the specified name, if any.</returns>
+    public static ReferenceableComponentDefinition? Get(this ComponentDefinitionCollection collection, Type type, string name)
+    {
+        ArgumentNullException.ThrowIfNull(collection);
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (type == typeof(AuthenticationPolicyDefinition))
+        {
+            if (collection.Authentications?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(ToolsetDefinition))
+        {
+            if (collection.Toolsets?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(PromptTemplateDefinition))
+        {
+            if (collection.Prompts?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(FunctionDefinition))
+        {
+            if (collection.Functions?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(MemoryDefinition))
+        {
+            if (collection.Memories?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(EmbeddingModelDefinition))
+        {
+            if (collection.Embedders?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(VectorStoreDefinition))
+        {
+            if (collection.Vectors?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(KnowledgeGraphDefinition))
+        {
+            if (collection.Graphs?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(LlmDefinition))
+        {
+            if (collection.Llms?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        if (type == typeof(AgentDefinition))
+        {
+            if (collection.Agents?.TryGetValue(name, out var component) == true) return component;
+            else return null;
+        }
+        return null;
+    }
+
+}

--- a/src/DClare.Sdk/Models/A2ACommunicationChannelDefinition.cs
+++ b/src/DClare.Sdk/Models/A2ACommunicationChannelDefinition.cs
@@ -33,7 +33,6 @@ public record A2ACommunicationChannelDefinition
     /// Gets or sets the unique name used to identify the remote agent.
     /// </summary>
     [Description("The unique name used to identify the remote agent.")]
-    [Required]
     [DataMember(Name = "name", Order = 2), JsonPropertyName("name"), JsonPropertyOrder(2), YamlMember(Alias = "name", Order = 2)]
     public virtual string? Name { get; set; }
 

--- a/src/DClare.Sdk/Models/AgentDefinition.cs
+++ b/src/DClare.Sdk/Models/AgentDefinition.cs
@@ -19,6 +19,7 @@ namespace DClare.Sdk.Models;
 [Description("Represents the definition of an AI agent")]
 [DataContract]
 public record AgentDefinition
+    : ReferenceableComponentDefinition
 {
 
     /// <summary>

--- a/src/DClare.Sdk/Models/ComponentDefinitionCollection.cs
+++ b/src/DClare.Sdk/Models/ComponentDefinitionCollection.cs
@@ -18,7 +18,7 @@ namespace DClare.Sdk.Models;
 /// </summary>
 [Description("Represents a collection of reusable components that can be referenced within a workflow.")]
 [DataContract]
-public record ComponentCollectionDefinition
+public record ComponentDefinitionCollection
 {
 
     /// <summary>

--- a/src/DClare.Sdk/Models/HostedAgentDefinition.cs
+++ b/src/DClare.Sdk/Models/HostedAgentDefinition.cs
@@ -22,39 +22,53 @@ public record HostedAgentDefinition
 {
 
     /// <summary>
+    /// Gets or sets the human-readable title of the agent.
+    /// </summary>
+    [Description("The human-readable title of the agent.")]
+    [DataMember(Name = "title", Order = 1), JsonInclude, JsonPropertyName("title"), JsonPropertyOrder(1), YamlMember(Alias = "title", Order = 1)]
+    public virtual string? Title { get; set; }
+
+    /// <summary>
     /// Gets or sets an optional human-readable description of the agent's purpose or role.
     /// </summary>
     [Description("Optional human-readable description of the agent's purpose or role.")]
-    [DataMember(Name = "description", Order = 1), JsonInclude, JsonPropertyName("description"), JsonPropertyOrder(1), YamlMember(Alias = "description", Order = 1)]
+    [DataMember(Name = "description", Order = 2), JsonInclude, JsonPropertyName("description"), JsonPropertyOrder(2), YamlMember(Alias = "description", Order = 2)]
     public virtual string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets a reference to the agent's documentation, either as a URI or an inline description.
+    /// </summary>
+    [Description("A reference to the agent's documentation, either as a URI or an inline description.")]
+    [DataMember(Name = "documentation", Order = 3), JsonInclude, JsonPropertyName("documentation"), JsonPropertyOrder(3), YamlMember(Alias = "documentation", Order = 3)]
+    public virtual OneOf<Uri, string>? Documentation { get; set; }
 
     /// <summary>
     /// Gets or sets the union value representing either a prompt template or a raw instruction string.
     /// </summary>
     [Required]
     [Description("Defines the agent's instructions, either as a raw string or a prompt template.")]
-    [DataMember(Name = "instructions", Order = 2), JsonInclude, JsonPropertyName("instructions"), JsonPropertyOrder(2), YamlMember(Alias = "instructions", Order = 2)]
+    [DataMember(Name = "instructions", Order = 4), JsonInclude, JsonPropertyName("instructions"), JsonPropertyOrder(4), YamlMember(Alias = "instructions", Order = 4)]
     public virtual OneOf<PromptTemplateDefinition, string> Instructions { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the dictionary of named skills the agent supports.
     /// </summary>
     [Description("A dictionary of named skills the agent supports.")]
-    [DataMember(Name = "skills", Order = 3), JsonInclude, JsonPropertyName("skills"), JsonPropertyOrder(3), YamlMember(Alias = "skills", Order = 3)]
+    [DataMember(Name = "skills", Order = 5), JsonInclude, JsonPropertyName("skills"), JsonPropertyOrder(5), YamlMember(Alias = "skills", Order = 5)]
     public virtual EquatableDictionary<string, AgentSkillDefinition>? Skills { get; set; }
 
     /// <summary>
     /// Gets or sets the memory definition used by the agent, if any.
     /// </summary>
     [Description("The memory configuration used by the agent, if any.")]
-    [DataMember(Name = "memory", Order = 4), JsonInclude, JsonPropertyName("memory"), JsonPropertyOrder(4), YamlMember(Alias = "memory", Order = 4)]
+    [DataMember(Name = "memory", Order = 6), JsonInclude, JsonPropertyName("memory"), JsonPropertyOrder(6), YamlMember(Alias = "memory", Order = 6)]
     public virtual MemoryDefinition? Memory { get; set; }
 
     /// <summary>
     /// Gets or sets the knowledge configuration used by the agent, if any.
     /// </summary>
     [Description("The knowledge configuration used by the agent, if any.")]
-    [DataMember(Name = "knowledge", Order = 5), JsonInclude, JsonPropertyName("knowledge"), JsonPropertyOrder(5), YamlMember(Alias = "knowledge", Order = 5)]
+    [DataMember(Name = "knowledge", Order = 7), JsonInclude, JsonPropertyName("knowledge"), JsonPropertyOrder(7), YamlMember(Alias = "knowledge", Order = 7)]
     public virtual KnowledgeDefinition? Knowledge { get; set; }
 
     /// <summary>
@@ -62,14 +76,14 @@ public record HostedAgentDefinition
     /// </summary>
     [Required]
     [Description("The definition of the LLM used by the agent.")]
-    [DataMember(Name = "llm", Order = 6), JsonInclude, JsonPropertyName("llm"), JsonPropertyOrder(6), YamlMember(Alias = "llm", Order = 6)]
+    [DataMember(Name = "llm", Order = 8), JsonInclude, JsonPropertyName("llm"), JsonPropertyOrder(8), YamlMember(Alias = "llm", Order = 8)]
     public virtual LlmDefinition Llm { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the toolsets the agent is capable of using.
     /// </summary>
     [Description("The toolsets the agent is capable of using.")]
-    [DataMember(Name = "toolsets", Order = 7), JsonInclude, JsonPropertyName("toolsets"), JsonPropertyOrder(7), YamlMember(Alias = "toolsets", Order = 7)]
+    [DataMember(Name = "toolsets", Order = 9), JsonInclude, JsonPropertyName("toolsets"), JsonPropertyOrder(9), YamlMember(Alias = "toolsets", Order = 9)]
     public virtual EquatableDictionary<string, ToolsetDefinition>? Toolsets { get; set; }
 
 }

--- a/src/DClare.Sdk/Models/WorkflowDefinition.cs
+++ b/src/DClare.Sdk/Models/WorkflowDefinition.cs
@@ -26,15 +26,15 @@ public record WorkflowDefinition
     /// </summary>
     [Description("The metadata used to describe with the workflow definition.")]
     [Required]
-    [DataMember(Name = "metadata", Order = 1), JsonPropertyName("metadata"), JsonPropertyOrder(1), YamlMember(Alias = "metadata", Order = 1)]
-    public virtual WorkflowDefinitionMetadata Metadata { get; set; } = null!;
+    [DataMember(Name = "document", Order = 1), JsonPropertyName("document"), JsonPropertyOrder(1), YamlMember(Alias = "document", Order = 1)]
+    public virtual WorkflowDefinitionMetadata Document { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets a collection of reusable components, if any, that can be referenced within the workflow.
     /// </summary>
     [Description("A collection of reusable components, if any, that can be referenced within the workflow.")]
     [DataMember(Name = "components", Order = 2), JsonPropertyName("components"), JsonPropertyOrder(2), YamlMember(Alias = "components", Order = 2)]
-    public virtual ComponentCollectionDefinition? Components { get; set; }
+    public virtual ComponentDefinitionCollection? Components { get; set; }
 
     /// <summary>
     /// Gets or sets the tasks to execute as part of the workflow. The key represents the task name, and the value is its definition.

--- a/tests/DClare.Sdk.UnitTests/Services/WorkflowDefinitionFactory.cs
+++ b/tests/DClare.Sdk.UnitTests/Services/WorkflowDefinitionFactory.cs
@@ -18,7 +18,7 @@ internal static class WorkflowDefinitionFactory
 
     internal static WorkflowDefinition Create() => new()
     {
-        Metadata = new()
+        Document = new()
         {
             Name = "fake-name",
             Version = "1.0.0",


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Updates the `HostedAgentDefinition` by adding a `Title` and a `Documentation` property
- Adds a new extension used to get any type of components from a `ComponentDefinitionCollection` in a generic way
- Fixes the `A2ACommunicationChannelDefinition` which wrongly marked the `Name` property has required